### PR TITLE
Resource/File Replace : with - in filename

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,10 @@ func GetResourceFileName(id resid.ResId, res *resource.Resource) (string, error)
 		return "", err
 	}
 
+	if strings.Contains(name, ":") {
+		name = strings.ReplaceAll(name, ":", "-")
+	}
+
 	return strings.ToLower(fmt.Sprintf("resources/%s-%s.yaml", name, GetKindAbbreviation(kind))), nil
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -41,6 +41,21 @@ func TestGetResourceFileName(t *testing.T) {
 			},
 			expected: "resources/my-deployment-deploy.yaml",
 		},
+		{
+			name: "it should return a filename",
+			input: getResourceFileNameArgs{
+				id: resid.NewResId(deploy, "deploy1"),
+				resource: rf.FromMap(
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name": "my:deployment",
+						},
+					}),
+			},
+			expected: "resources/my-deployment-deploy.yaml",
+		},
 	} {
 		t.Run(fmt.Sprintf("%s", test.name), func(t *testing.T) {
 			output, err := GetResourceFileName(test.input.id, test.input.resource)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -42,7 +42,7 @@ func TestGetResourceFileName(t *testing.T) {
 			expected: "resources/my-deployment-test-deploy.yaml",
 		},
 		{
-			name: "it should return a filename with -",
+			name: "it should return a filename with no colon",
 			input: getResourceFileNameArgs{
 				id: resid.NewResId(deploy, "deploy1"),
 				resource: rf.FromMap(

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -35,14 +35,14 @@ func TestGetResourceFileName(t *testing.T) {
 						"apiVersion": "v1",
 						"kind":       "Deployment",
 						"metadata": map[string]interface{}{
-							"name": "my-deployment",
+							"name": "my-deployment:test",
 						},
 					}),
 			},
-			expected: "resources/my-deployment-deploy.yaml",
+			expected: "resources/my-deployment-test-deploy.yaml",
 		},
 		{
-			name: "it should return a filename",
+			name: "it should return a filename with -",
 			input: getResourceFileNameArgs{
 				id: resid.NewResId(deploy, "deploy1"),
 				resource: rf.FromMap(


### PR DESCRIPTION
**What**
If a chart has `:` in its name, then filename in resources/<file-name>.yaml will also have `:` and this causes problem on windows machine, so replacing `:` with `-` would fix the problem