### PR TITLE
Remove helm label helm.sh/chart

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -221,7 +221,7 @@ func (k *convertCmd) run() error {
 	}
 
 	defaultTransfomers := []transformers.Transformer{
-		transformers.NewLabelsTransformer([]string{"chart", "release", "heritage"}),
+		transformers.NewLabelsTransformer([]string{"chart", "release", "heritage", "helm.sh/chart"}),
 		transformers.NewAnnotationsTransformer([]string{
 			hooks.HookAnno,
 			hooks.HookWeightAnno,

--- a/pkg/transformers/labels_test.go
+++ b/pkg/transformers/labels_test.go
@@ -222,9 +222,10 @@ func TestLabelsRun(t *testing.T) {
 								"metadata": map[string]interface{}{
 									"name": "cm1",
 									"labels": map[string]interface{}{
-										"chart":    "nginx",
-										"heritage": "Tiller",
-										"release":  "nginx",
+										"chart":         "nginx",
+										"heritage":      "Tiller",
+										"release":       "nginx",
+										"helm.sh/chart": "1.5.2",
 									},
 								},
 							}),
@@ -235,9 +236,10 @@ func TestLabelsRun(t *testing.T) {
 								"metadata": map[string]interface{}{
 									"name": "deploy1",
 									"labels": map[string]interface{}{
-										"chart":    "nginx",
-										"heritage": "Tiller",
-										"release":  "nginx",
+										"chart":         "nginx",
+										"heritage":      "Tiller",
+										"release":       "nginx",
+										"helm.sh/chart": "1.5.2",
 									},
 								},
 							}),
@@ -248,16 +250,18 @@ func TestLabelsRun(t *testing.T) {
 								"metadata": map[string]interface{}{
 									"name": "service1",
 									"labels": map[string]interface{}{
-										"chart":    "nginx",
-										"heritage": "Tiller",
-										"release":  "nginx",
+										"chart":         "nginx",
+										"heritage":      "Tiller",
+										"release":       "nginx",
+										"helm.sh/chart": "1.5.2",
 									},
 								},
 								"spec": map[string]interface{}{
 									"selector": map[string]interface{}{
-										"chart":    "nginx",
-										"heritage": "Tiller",
-										"release":  "nginx",
+										"chart":         "nginx",
+										"heritage":      "Tiller",
+										"release":       "nginx",
+										"helm.sh/chart": "1.5.2",
 									},
 								},
 							}),
@@ -268,17 +272,19 @@ func TestLabelsRun(t *testing.T) {
 								"metadata": map[string]interface{}{
 									"name": "poddisruptionbudget1",
 									"labels": map[string]interface{}{
-										"chart":    "nginx",
-										"heritage": "Tiller",
-										"release":  "nginx",
+										"chart":         "nginx",
+										"heritage":      "Tiller",
+										"release":       "nginx",
+										"helm.sh/chart": "1.5.2",
 									},
 								},
 								"spec": map[string]interface{}{
 									"selector": map[string]interface{}{
 										"matchLabels": map[string]interface{}{
-											"chart":    "nginx",
-											"heritage": "Tiller",
-											"release":  "nginx",
+											"chart":         "nginx",
+											"heritage":      "Tiller",
+											"release":       "nginx",
+											"helm.sh/chart": "1.5.2",
 										},
 									},
 								},
@@ -340,7 +346,7 @@ func TestLabelsRun(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("%s", test.name), func(t *testing.T) {
-			lt := NewLabelsTransformer([]string{"chart", "release", "heritage"})
+			lt := NewLabelsTransformer([]string{"chart", "release", "heritage", "helm.sh/chart"})
 			err := lt.Transform(test.input.config, test.input.resources)
 
 			if err != nil {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 ---
 name: "convert"
-version: "0.6.3"
+version: "0.6.4"
 usage: "convert"
 description: |-
   Convert Helm charts into Kustomize compatible package


### PR DESCRIPTION
**What**
Converter add commonLabel `helm.sh/chart` with chart version as its value and it would potentially cause issues when we would update the deployed, so remove this label from the convert. 